### PR TITLE
BZ-1147929 - Business central cannot be started on WebSphere due to CDI ...

### DIFF
--- a/kie-uberfire-runtime-plugins/kie-uberfire-runtime-plugins-backend/src/main/java/org/kie/uberfire/plugin/backend/PluginServicesImpl.java
+++ b/kie-uberfire-runtime-plugins/kie-uberfire-runtime-plugins-backend/src/main/java/org/kie/uberfire/plugin/backend/PluginServicesImpl.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -69,7 +70,7 @@ public class PluginServicesImpl implements PluginServices {
 
     @Inject
     @Named("MediaServletURI")
-    private MediaServletURI mediaServletURI;
+    private Instance<MediaServletURI> mediaServletURI;
 
     @Inject
     private transient SessionInfo sessionInfo;
@@ -95,7 +96,7 @@ public class PluginServicesImpl implements PluginServices {
 
     @Override
     public String getMediaServletURI() {
-        return mediaServletURI.getURI();
+        return mediaServletURI.get().getURI();
     }
 
     @Override

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/adapters/SocialRouter.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/adapters/SocialRouter.java
@@ -21,7 +21,7 @@ public class SocialRouter implements SocialRouterAPI {
     private Map<Class, SocialAdapter> socialAdapters;
 
     @PostConstruct
-    public void setup() throws ServletException {
+    public void setup() {
         socialAdapters = socialAdapterRepositoryAPI.getSocialAdapters();
     }
 

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/repository/SocialAdapterRepository.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/repository/SocialAdapterRepository.java
@@ -18,7 +18,7 @@ public class SocialAdapterRepository implements SocialAdapterRepositoryAPI {
 
     @Inject
     @Any
-    private Instance<SocialAdapter> services;
+    private Instance<SocialAdapter<?>> services;
 
     @PostConstruct
     public void setup() {

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/server/SocialActivitiesEventObserver.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/server/SocialActivitiesEventObserver.java
@@ -2,9 +2,10 @@ package org.kie.uberfire.social.activities.server;
 
 import java.util.Map;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
+import javax.enterprise.event.Reception;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 
@@ -12,8 +13,10 @@ import org.kie.uberfire.social.activities.model.SocialActivitiesEvent;
 import org.kie.uberfire.social.activities.service.SocialActivitiesAPI;
 import org.kie.uberfire.social.activities.service.SocialAdapter;
 import org.kie.uberfire.social.activities.service.SocialAdapterRepositoryAPI;
+import org.uberfire.commons.services.cdi.Startup;
 
-@Dependent
+@Startup
+@ApplicationScoped
 public class SocialActivitiesEventObserver {
 
     @Inject
@@ -39,7 +42,10 @@ public class SocialActivitiesEventObserver {
         socialAPI.register( event );
     }
 
-    public void observeAllEvents( @Observes Object event ) {
+    public void observeAllEvents( @Observes(notifyObserver = Reception.IF_EXISTS) Object event ) {
+        if (socialAdapters == null) {
+            return;
+        }
         for ( Map.Entry<Class, SocialAdapter> entry : socialAdapters.entrySet() ) {
             SocialAdapter adapter = entry.getValue();
             if ( adapter.shouldInterceptThisEvent( event ) ) {

--- a/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/servlet/SocialRouter.java
+++ b/kie-uberfire-social-activities/kie-uberfire-social-activities-backend/src/main/java/org/kie/uberfire/social/activities/servlet/SocialRouter.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.servlet.ServletException;
 
 import org.kie.uberfire.social.activities.service.SocialAdapter;
 import org.kie.uberfire.social.activities.service.SocialAdapterRepositoryAPI;
@@ -18,7 +17,7 @@ public class SocialRouter {
     private Map<Class, SocialAdapter> socialAdapters;
 
     @PostConstruct
-    public void setup() throws ServletException {
+    public void setup() {
         socialAdapters = socialAdapterRepositoryAPI.getSocialAdapters();
     }
 


### PR DESCRIPTION
...UnsatisfiedResolutionException on type SocialAdapterRepositoryAPI

several things to notice here:
- somehow PluginServicesImpl does not get the injection of MediaServletURI so I made it temporarily wrapped with Instance to not fail at deploy time
- SocialActivitiesEventObserver is listening for all events (Object event) and thus when being marked as @Dependant was receiving events for it was fully initialized and thus causing lots of issues. Not it's application scoped and is startup bean so it will be active as soon app starts
- @PostConstruct methods cannot throw checked exceptions

as far as I could test it works fine on both JBoss and WAS but since I don't know these features well please give it a look. At least with this application deploys on WAS so it does not block QE from doing tests.
