### PR TITLE
changed uberfire-bom version to KIE version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
-        <version>${version.org.uberfire}</version>
+        <version>${version.org.kie}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The commit https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/34dfe2ec1c3634a0d06db0b16f49b57e5e085301 moved uberfire-bom from appformer into droolsjbpm-build-bootstrap, with uberfire-bom version kept as Appformer version. Since this is not very user-friendly and breaks product build, this PR proposes a change of uberfire-bom version to KIE version to align it with the rest of the BOMs.

Related PRs: 
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1009
- https://github.com/kiegroup/droolsjbpm-integration/pull/1873
- https://github.com/kiegroup/appformer/pull/746
- https://github.com/kiegroup/drools-wb/pull/1198
- https://github.com/kiegroup/jbpm-designer/pull/856
- https://github.com/kiegroup/kie-wb-common/pull/2780
- https://github.com/kiegroup/jbpm-wb/pull/1375
- https://github.com/kiegroup/kie-wb-distributions/pull/947
- https://github.com/kiegroup/optaplanner-wb/pull/342